### PR TITLE
Feat: add stopped time in manage timers

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "marcjulian",
     "GastroGeek",
     "pernielsentikaer",
-    "lokot0k"
+    "lokot0k",
+    "mitchwu"
   ],
   "categories": [
     "Productivity",

--- a/src/manageTimers.tsx
+++ b/src/manageTimers.tsx
@@ -4,7 +4,6 @@ import useTimers from "./hooks/useTimers";
 import RenameView from "./RenameView";
 import CustomTimerView from "./startCustomTimer";
 import { formatDateTime, formatTime } from "./formatUtils";
-import { getTimeAfterSeconds } from "./timeCalculationUtils";
 
 export default function Command() {
   const {
@@ -40,7 +39,7 @@ export default function Command() {
             subtitle={formatTime(timer.timeLeft) + " left"}
             accessories={[
               { text: formatTime(timer.secondsSet) + " originally" },
-              { text: `Ends at ${formatDateTime(getTimeAfterSeconds(timer.timeLeft))}` },
+              { text: `${timer.timeLeft === 0 ? "Ended" : "Ends"} at ${formatDateTime(timer.timeEnds)}` },
               timer.timeLeft === 0 ? finishedIcon : runningIcon,
             ]}
             actions={

--- a/src/manageTimers.tsx
+++ b/src/manageTimers.tsx
@@ -26,18 +26,22 @@ export default function Command() {
     }, 1000);
   }, []);
 
+  const runningIcon = { tag: { value: "Running", color: Color.Yellow } };
+  const finishedIcon = { tag: { value: "Finished!", color: Color.Green } };
+
   return (
     <List isLoading={isLoading}>
       <List.Section title={timers?.length !== 0 && timers != null ? "Currently Running" : "No Timers Running"}>
         {timers?.map((timer) => (
           <List.Item
             key={timer.originalFile}
-            icon={{ source: Icon.Clock, tintColor: Color.Yellow }}
+            icon={{ source: Icon.Clock, tintColor: timer.timeLeft === 0 ? Color.Green : Color.Yellow }}
             title={timer.name}
             subtitle={formatTime(timer.timeLeft) + " left"}
             accessories={[
               { text: formatTime(timer.secondsSet) + " originally" },
-              { text: `(${formatDateTime(getTimeAfterSeconds(timer.timeLeft))})`}
+              { text: `Ends at ${formatDateTime(getTimeAfterSeconds(timer.timeLeft))}` },
+              timer.timeLeft === 0 ? finishedIcon : runningIcon,
             ]}
             actions={
               <ActionPanel>

--- a/src/manageTimers.tsx
+++ b/src/manageTimers.tsx
@@ -3,7 +3,8 @@ import { useEffect } from "react";
 import useTimers from "./hooks/useTimers";
 import RenameView from "./RenameView";
 import CustomTimerView from "./startCustomTimer";
-import { formatTime } from "./formatUtils";
+import { formatDateTime, formatTime } from "./formatUtils";
+import { getTimeAfterSeconds } from "./timeCalculationUtils";
 
 export default function Command() {
   const {
@@ -34,7 +35,10 @@ export default function Command() {
             icon={{ source: Icon.Clock, tintColor: Color.Yellow }}
             title={timer.name}
             subtitle={formatTime(timer.timeLeft) + " left"}
-            accessories={[{ text: formatTime(timer.secondsSet) + " originally" }]}
+            accessories={[
+              { text: formatTime(timer.secondsSet) + " originally" },
+              { text: `(${formatDateTime(getTimeAfterSeconds(timer.timeLeft))})`}
+            ]}
             actions={
               <ActionPanel>
                 <Action title="Stop Timer" onAction={() => handleStopTimer(timer)} />

--- a/src/timeCalculationUtils.ts
+++ b/src/timeCalculationUtils.ts
@@ -1,7 +1,0 @@
-const getTimeAfterSeconds = (seconds: number): Date => {
-  const now = new Date();
-  const milliseconds = seconds * 1000;
-  return new Date(now.getTime() + milliseconds);
-}
-
-export { getTimeAfterSeconds };

--- a/src/timeCalculationUtils.ts
+++ b/src/timeCalculationUtils.ts
@@ -1,0 +1,7 @@
+const getTimeAfterSeconds = (seconds: number): Date => {
+  const now = new Date();
+  const milliseconds = seconds * 1000;
+  return new Date(now.getTime() + milliseconds);
+}
+
+export { getTimeAfterSeconds };

--- a/src/timerUtils.ts
+++ b/src/timerUtils.ts
@@ -79,12 +79,15 @@ function getTimers() {
         secondsSet: -99,
         timeLeft: -99,
         originalFile: timerFile,
+        timeEnds: new Date(),
       };
       timer.name = readFileSync(environment.supportPath + "/" + timerFile).toString();
       const timerFileParts = timerFile.split("---");
       timer.secondsSet = Number(timerFileParts[1].split(".")[0]);
       const timeStarted = timerFileParts[0].replace(/__/g, ":");
       timer.timeLeft = Math.max(0, Math.round(timer.secondsSet - secondsBetweenDates({ d2: timeStarted })));
+      timer.timeEnds = new Date(timeStarted);
+      timer.timeEnds.setSeconds(timer.timeEnds.getSeconds() + timer.secondsSet);
       setOfTimers.push(timer);
     }
   });

--- a/src/types.ts
+++ b/src/types.ts
@@ -5,6 +5,7 @@ export interface Timer {
   secondsSet: number;
   timeLeft: number;
   originalFile: string;
+  timeEnds: Date;
 }
 
 export interface Stopwatch {


### PR DESCRIPTION
Hi @ThatNerdSquared ,

I have added a stopped time at the end of the line in the "manage timers" command, 
which makes it easier for users to know when the timers have stopped.

Additionally, I created a new file called "timeCalculationUtils" and added the function "getTimeAfterSeconds" to it.
Because I am unsure whether adding this function to the following two files is a good idea or not:

timerUtils: This file appears to be related to timers.
formatTimeUtils: This file appears to be related to time formatting.

![image](https://user-images.githubusercontent.com/11547758/236425498-15c2b089-4f95-4c97-9cfa-4937ea87cfca.png)
