### PR TITLE
fix: timer still ringing when stop

### DIFF
--- a/src/timerUtils.ts
+++ b/src/timerUtils.ts
@@ -64,7 +64,7 @@ async function startTimer(timeInSeconds: number, timerName = "Untitled", selecte
 function stopTimer(timerFile: string) {
   const timerFilePath = environment.supportPath + "/" + timerFile;
   const deleteTimerCmd = `if [ -f "${timerFilePath}" ]; then rm "${timerFilePath}"; else echo "Timer deleted"; fi`;
-  const dismissFile = timerFile.replace(".timer", ".dismiss");
+  const dismissFile = timerFilePath.replace(".timer", ".dismiss");
   const deleteDismissCmd = `if [ -f "${dismissFile}" ]; then rm "${dismissFile}"; else echo "Timer deleted"; fi`;
   execSync(deleteTimerCmd);
   execSync(deleteDismissCmd);


### PR DESCRIPTION
Fixed an issue where the ring continued to play even after the timer was stopped due to incorrect dismiss file path.