### PR TITLE
Added 'Timer by Seconds' & 'Timer by Minutes' feature

### DIFF
--- a/package.json
+++ b/package.json
@@ -91,6 +91,40 @@
       "disabledByDefault": true
     },
     {
+      "name": "startTimerBySeconds",
+      "title": "Start Timer by Seconds",
+      "description": "(SPAUPA) Set a countdown for a custom amount of seconds.",
+      "mode": "no-view",
+      "keywords": [
+        "tim"
+      ],
+      "arguments": [
+        {
+          "name": "value",
+          "placeholder": "seconds",
+          "required": true,
+          "type": "text"
+        }
+      ]
+    },
+    {
+      "name": "startTimerByMinutes",
+      "title": "Start Timer by Minutes",
+      "description": "(SPAUPA) Set a countdown for a custom amount of minutes.",
+      "mode": "no-view",
+      "keywords": [
+        "tis"
+      ],
+      "arguments": [
+        {
+          "name": "value",
+          "placeholder": "minutes",
+          "required": true,
+          "type": "text"
+        }
+      ]
+    },
+    {
       "name": "startCustomTimer",
       "title": "Start Custom Timer",
       "description": "Set a countdown for a custom amount of time.",

--- a/package.json
+++ b/package.json
@@ -93,7 +93,7 @@
     {
       "name": "startTimerBySeconds",
       "title": "Start Timer by Seconds",
-      "description": "(SPAUPA) Set a countdown for a custom amount of seconds.",
+      "description": "Set a countdown for a custom amount of seconds.",
       "mode": "no-view",
       "keywords": [
         "tim"
@@ -110,7 +110,7 @@
     {
       "name": "startTimerByMinutes",
       "title": "Start Timer by Minutes",
-      "description": "(SPAUPA) Set a countdown for a custom amount of minutes.",
+      "description": "Set a countdown for a custom amount of minutes.",
       "mode": "no-view",
       "keywords": [
         "tis"

--- a/src/startTimerByMinutes.ts
+++ b/src/startTimerByMinutes.ts
@@ -2,5 +2,6 @@ import { checkForOverlyLoudAlert, startTimer } from "./backend/timerBackend";
 
 export default async (props: { arguments: { value: number } }) => {
   if (!checkForOverlyLoudAlert()) return;
-  await startTimer({ timeInSeconds: props.arguments.value * 60, timerName: "10 Minute Timer" });
+  const value = props.arguments.value;
+  await startTimer({ timeInSeconds: value * 60, timerName: `${value} Minute${value >= 2 ? 's' : ''} Timer` });
 };

--- a/src/startTimerByMinutes.ts
+++ b/src/startTimerByMinutes.ts
@@ -1,0 +1,6 @@
+import { checkForOverlyLoudAlert, startTimer } from "./backend/timerBackend";
+
+export default async (props: { arguments: { value: number } }) => {
+  if (!checkForOverlyLoudAlert()) return;
+  await startTimer({ timeInSeconds: props.arguments.value * 60, timerName: "10 Minute Timer" });
+};

--- a/src/startTimerBySeconds.ts
+++ b/src/startTimerBySeconds.ts
@@ -1,0 +1,6 @@
+import { checkForOverlyLoudAlert, startTimer } from "./backend/timerBackend";
+
+export default async (props: { arguments: { value: number } }) => {
+  if (!checkForOverlyLoudAlert()) return;
+  await startTimer({ timeInSeconds: props.arguments.value, timerName: "Custom Timer" });
+};

--- a/src/startTimerBySeconds.ts
+++ b/src/startTimerBySeconds.ts
@@ -2,5 +2,6 @@ import { checkForOverlyLoudAlert, startTimer } from "./backend/timerBackend";
 
 export default async (props: { arguments: { value: number } }) => {
   if (!checkForOverlyLoudAlert()) return;
-  await startTimer({ timeInSeconds: props.arguments.value, timerName: "Custom Timer" });
+  const value = props.arguments.value;
+  await startTimer({ timeInSeconds: value, timerName: `${value} Second${value >= 2 ? 's' : ''} Timer` });
 };


### PR DESCRIPTION
Created two commands for quickly creating a timer with custom duration, which is a bit more keyboard friendly than existing Custom Timer feature. (ex: `tis<Tab>30<CR>` -> 30 seconds timer)

This was a little feature that I really wished it had, so I wrote it myself :) But I'm afraid that they might feel a bit redundant to others, since Custom Timer feature already exists. So check the changed files (It won't be a lot) and see if you think they fit.